### PR TITLE
Fix raw string warning in Python 3.12

### DIFF
--- a/P4Transfer.py
+++ b/P4Transfer.py
@@ -1623,7 +1623,7 @@ class P4Target(P4Base):
                     self.p4.run(cmd)
                     result = self.p4cmd("submit", "-c", m.group(1))
                 else:  # Check for utf16 type problems and change them to binary to see if that works
-                    re_transferProblems = re.compile(".*fix problems then use 'p4 submit -c ([0-9]+)'.\nSome file\(s\) could not be transferred from client")
+                    re_transferProblems = re.compile(r".*fix problems then use 'p4 submit -c ([0-9]+)'.\nSome file\(s\) could not be transferred from client")
                     re_translation = re.compile("Translation of file content failed near line [0-9]+ file (.*)")
                     m = re_transferProblems.search(self.p4.errors[0])
                     if not m:


### PR DESCRIPTION
Fix #27